### PR TITLE
Add wave function collapse algorithm

### DIFF
--- a/src/tiled_tools/common/queues.py
+++ b/src/tiled_tools/common/queues.py
@@ -1,0 +1,138 @@
+"""
+Implementations of various types of queues
+"""
+
+from typing import Any, Optional, Union
+
+from src.tiled_tools.common.custom_typing import AnyNumber
+
+
+class AbstractQueue:
+    """
+    An abstract queue class that defines the interface for all queue implementations
+    """
+
+    def __init__(self, starting_items: Optional[list] = None):
+        self.queue = []
+
+        if starting_items is not None:
+            for item in starting_items:
+                self.push(item)
+
+    def push(self, item):
+        """
+        Adds an item to the queue
+        """
+        raise NotImplementedError
+
+    def pop(self):
+        """Removes and returns the first item in the queue"""
+        raise NotImplementedError
+
+    def peek(self):
+        """Returns the first item in the queue without removing it"""
+        raise NotImplementedError
+
+    def is_empty(self):
+        """Returns True if the queue is empty"""
+        return len(self.queue) == 0
+
+    def __len__(self):
+        return len(self.queue)
+
+    def __repr__(self) -> str:
+        return f"{self.__class__.__name__}({self.queue})"
+
+    def __str__(self) -> str:
+        return self.__repr__()
+
+
+class Queue(AbstractQueue):
+    """
+    A basic queue implementation
+    """
+
+    def push(self, item):
+        self.queue.append(item)
+
+    def pop(self):
+        return self.queue.pop(0)
+
+    def peek(self):
+        return self.queue[0]
+
+
+class Stack(AbstractQueue):
+    """
+    A basic stack implementation
+    """
+
+    def push(self, item):
+        self.queue.append(item)
+
+    def pop(self):
+        return self.queue.pop(-1)
+
+    def peek(self):
+        return self.queue[-1]
+
+
+class PriorityWrapper:
+    """
+    A simple class that stores an item with its priority
+    and helps with comparison. The higher the priority,
+    the earlier the item will be popped from the queue
+    """
+
+    def __init__(self, item: Any, priority: AnyNumber):
+        self.item = item
+        self.priority = priority
+
+    def __lt__(self, other):
+        return self.priority < other.priority
+
+    def __eq__(self, other):
+        return self.priority == other.priority and self.item == other.item
+
+    def __gt__(self, other):
+        return self.priority > other.priority
+
+    def __le__(self, other):
+        return self.priority <= other.priority
+
+    def __ge__(self, other):
+        return self.priority >= other.priority
+
+    def __ne__(self, other):
+        return self.priority != other.priority
+
+    def __repr__(self) -> str:
+        return str(self.item)
+
+
+class PriorityQueue(AbstractQueue):
+    """
+    A priority queue
+    """
+
+    def push(self, item: Union[PriorityWrapper, tuple, Any]):
+        """
+        Args:
+            item (Union[PriorityWrapper,tuple]): The item to add to the queue. If a tuple is provided, it will be
+            converted to a PriorityWrapper with the second element as the priority.
+
+        """
+        if isinstance(item, PriorityWrapper):
+            self.queue.append(item)
+        elif isinstance(item, tuple):
+            self.queue.append(PriorityWrapper(item[0], item[1]))
+        else:
+            self.queue.append(PriorityWrapper(item, 0))
+
+        self.queue.sort()
+
+    def pop(self):
+        return self.queue.pop(-1).item
+
+    def peek(self):
+        return self.queue[-1].item

--- a/src/tiled_tools/map/algorithms.py
+++ b/src/tiled_tools/map/algorithms.py
@@ -1,0 +1,174 @@
+import random
+from enum import Enum
+from typing import Optional
+
+from src.tiled_tools.common.grid import Grid, WrapDirection
+from src.tiled_tools.common.queues import Queue
+
+from .map import ISLAND_RULESET, TileRuleSet, TileType
+
+
+class QuantumState:
+    """
+    A wrapper around a tile type that represents the possible states
+    remaining for a specific tile. It defaults to use the TileType enum,
+    but can be used with any enum, trying to figure out the best way to get typing
+    to work with this.
+    """
+
+    def __init__(self, tile_enum: TileType):
+        self.tile_enum = tile_enum
+        self.possible_states = [tile for tile in tile_enum]
+
+    def collapse(self, tile: Enum):
+        """
+        Collapses the possible states to a single state
+        """
+        self.possible_states = [tile]
+
+    def remove_state(self, tile: Enum):
+        """
+        Removes a state from the possible states
+        """
+        self.possible_states.remove(tile)
+
+    def remove_contrary_states(self, tile: TileType, ruleset: TileRuleSet):
+        """
+        Removes states that are not allowed by the ruleset, given that a neighbor
+        tile was observed to be of a certain type.
+        """
+        to_remove = []
+        for state in self.possible_states:
+            if not ruleset.is_allowed_neighbor(tile, state):
+                to_remove.append(state)
+
+        for state in to_remove:
+            self.possible_states.remove(state)
+
+    def __repr__(self):
+        if len(self.possible_states) == 1:
+            return f"QuantumState({self.possible_states[0].name})"
+
+        names = ", ".join([f"{state.name}?" for state in self.possible_states])
+        return f"QuantumState({names})"
+
+    def __str__(self):
+        return self.__repr__()
+
+
+class WaveFunctionCollapse:
+    """
+    I started this whole project because of how interesting this
+    algorithm is.
+    """
+
+    def __init__(
+        self,
+        ruleset: TileRuleSet,
+        grid: Grid,
+        desired_ratios: dict[TileType, float],
+        neighbor_depth: int = 1,
+    ):
+        self.ruleset = ruleset
+        self.grid = grid
+        self.desired_ratios = desired_ratios
+        self.neighbor_depth = neighbor_depth
+
+    def collapse(self):
+        """
+        Runs the entire collapse algorithm until the grid is fully collapsed
+        """
+        uncollapsed = self.uncollapsed()
+
+        while len(uncollapsed) > 0:
+            c, r = self.random_uncollapsed()
+            self.collapse_cell(c, r)
+            self.propagate_collapse(c, r)
+            self.remove_global_contrary_states()
+            uncollapsed = self.uncollapsed()
+
+    def collapse_cell(self, col: int, row: int):
+        """
+        Collapses a specific cell in the grid
+        """
+        cell = self.grid.get(col, row)
+        remain_states = cell.possible_states
+        observed = random.choice(remain_states)
+
+        cell.collapse(observed)
+
+    def remove_global_contrary_states(self):
+        """
+        This is not much of a problem on the 2D grid, but may be on
+        hex grids. Will need to update it to resolve those issues.
+        """
+        pass
+
+    def collapse_random(self) -> Optional[tuple[int, int]]:
+        """
+        Collapses a random tile in the grid. Returns the
+        coordinates of the collapsed tile, or None if the grid
+        is fully collapsed.
+        """
+
+        quantum_remaining = self.uncollapsed()
+
+        if len(quantum_remaining) == 0:
+            return None
+
+        c, r = random.choice(list(quantum_remaining))
+        cell = self.grid.get(c, r)
+        remain_states = cell.possible_states
+        observed = random.choice(remain_states)
+
+        cell.collapse(observed)
+
+        return c, r
+
+    def propagate_collapse(self, col: int, row: int):
+        """
+        Propagates the collapse of a tile to its neighbors
+        """
+        visited = set()
+        collapsing = Queue([(col, row)])
+
+        while len(collapsing) > 0:
+            to_collapsed = collapsing.pop()
+            visited.add(to_collapsed)
+
+            collapsed_cell = self.grid.get(*to_collapsed)
+
+            for c, r in self.grid.get_adjacent_coords(*to_collapsed):
+                if (c, r) in visited:
+                    continue
+
+                neighbor: QuantumState = self.grid.get(c, r)
+                neighbor.remove_contrary_states(
+                    collapsed_cell.possible_states[0], self.ruleset
+                )
+
+                if len(neighbor.possible_states) == 1:
+                    collapsing.push((c, r))
+
+    def uncollapsed(self) -> set[tuple[int, int]]:
+        """
+        Returns the set of uncollapsed cells in the grid
+        """
+
+        uncollapsed = set()
+
+        for r in range(self.grid.height):
+            for c in range(self.grid.width):
+                if len(self.grid.get(c, r).possible_states) > 1:
+                    uncollapsed.add((c, r))
+
+        return uncollapsed
+
+    def random_uncollapsed(self) -> tuple[int, int]:
+        """
+        Returns the coordinates of a random uncollapsed cell
+        """
+
+        uncollapsed = self.uncollapsed()
+
+        return random.choice(list(uncollapsed))

--- a/src/tiled_tools/map/map.py
+++ b/src/tiled_tools/map/map.py
@@ -1,0 +1,175 @@
+"""
+A module for generating maps, and the rules for generating them. It will be used
+with wave function collapse to generate maps automatically
+"""
+from enum import Enum
+
+
+class TileType(Enum):
+    """
+    Represents the type of a tile when generating
+    """
+
+    OCEAN = 0
+    SAND = 1
+    FOREST = 2
+    STONE = 3
+    GRASS = 4
+
+
+class Tile:
+    """
+    Represents the smallest unit of a map, when generating
+    """
+
+    def __init__(self, tile_type: TileType, height: float = 0.0):
+        self.tile_type = tile_type
+        self.height = height
+
+
+class TileRule:
+    """
+    Rules for which tiles can be placed next to each other. Normalizes the weights of the
+    allowed neighbors to sum to 1, and fills in the missing neighbors with a weight of 0
+
+    Args:
+        tile_type (TileType): The root tile type
+        allowed_neighbors (dict[TileType, float]): The allowed neighbors and their weights
+    """
+
+    def __init__(self, tile_type: TileType, allowed_neighbors: dict[TileType, float]):
+        self.tile_type = tile_type
+        self.neighbor_weights = allowed_neighbors
+
+        weight_sum = sum(self.neighbor_weights.values())
+
+        assert weight_sum > 0, "The sum of the weights must be greater than 0"
+
+        for t_type in TileType:
+            if t_type not in allowed_neighbors:
+                self.neighbor_weights[t_type] = 0.0
+            else:
+                self.neighbor_weights[t_type] /= weight_sum
+
+
+class TileRuleSet:
+    """
+    A set of rules for which tiles can be placed next to each other. Seems like
+    the may need to be a reflexive rule for each tile type, but I'm not sure yet
+
+    Args:
+        rules (list[TileRule]): The rules for the tiles
+    """
+
+    def __init__(self, rules: list[dict[TileType, float]]):
+        self.rules: dict[TileType, TileRule] = {rule.tile_type: rule for rule in rules}
+
+    def get_rule(self, tile_type: TileType) -> TileRule:
+        """
+        Get the rule for a specific tile type
+
+        Args:
+            tile_type (TileType): The type of the tile
+
+        Returns:
+            TileRule: The rule for the tile type
+        """
+        return self.rules[tile_type]
+
+    def get_allowed_neighbors(self, tile_type: TileType) -> list[TileType]:
+        """
+        Get the allowed neighbors for a specific tile type
+
+        Args:
+            tile_type (TileType): The type of the tile
+
+        Returns:
+            list[TileType]: The allowed neighbors and their weights
+        """
+        allowed = [
+            tile_type
+            for tile_type, weight in self.rules[tile_type].neighbor_weights.items()
+            if weight > 0
+        ]
+
+        return allowed
+
+    def is_allowed_neighbor(self, tile_type: TileType, neighbor_type: TileType) -> bool:
+        """
+        Check if a neighbor type is allowed for a specific tile type
+
+        Args:
+            tile_type (TileType): The type of the tile
+            neighbor_type (TileType): The type of the neighbor
+
+        Returns:
+            bool: If the neighbor type is allowed
+        """
+        allowed_neighbors = self.get_allowed_neighbors(tile_type)
+        return neighbor_type in allowed_neighbors
+
+    def get_weight(self, tile_type: TileType, neighbor_type: TileType) -> float:
+        """
+        Get the weight of a neighbor type for a specific tile type
+
+        Args:
+            tile_type (TileType): The type of the tile
+            neighbor_type (TileType): The type of the neighbor
+
+        Returns:
+            float: The weight of the neighbor type
+        """
+        return self.get_rule(tile_type).neighbor_weights[neighbor_type]
+
+
+# Basic Rules for generating "islands",
+# where ocean tiles can be next to sand tiles, and sand tiles being able
+# to be next to any other tile type.
+island_rules = [
+    TileRule(
+        TileType.OCEAN,
+        {
+            TileType.OCEAN: 1,
+            TileType.SAND: 1,
+        },
+    ),
+    TileRule(
+        TileType.SAND,
+        {
+            TileType.OCEAN: 1,
+            TileType.SAND: 1,
+            TileType.FOREST: 1,
+            TileType.GRASS: 1,
+            TileType.STONE: 1,
+        },
+    ),
+    TileRule(
+        TileType.FOREST,
+        {
+            TileType.SAND: 1,
+            TileType.FOREST: 1,
+            TileType.GRASS: 1,
+            TileType.STONE: 1,
+        },
+    ),
+    TileRule(
+        TileType.GRASS,
+        {
+            TileType.SAND: 1,
+            TileType.FOREST: 1,
+            TileType.GRASS: 1,
+            TileType.STONE: 1,
+        },
+    ),
+    TileRule(
+        TileType.STONE,
+        {
+            TileType.SAND: 1,
+            TileType.FOREST: 1,
+            TileType.GRASS: 1,
+            TileType.STONE: 1,
+        },
+    ),
+]
+
+ISLAND_RULESET = TileRuleSet(island_rules)

--- a/tests/unit/test_algorithms.py
+++ b/tests/unit/test_algorithms.py
@@ -1,0 +1,74 @@
+# pylint: disable=missing-docstring
+
+import unittest
+
+from src.tiled_tools.common.grid import Grid, HexGrid, WrapDirection
+from src.tiled_tools.map.algorithms import QuantumState, WaveFunctionCollapse
+from src.tiled_tools.map.map import ISLAND_RULESET, TileType
+
+
+class TestQuantumState(unittest.TestCase):
+    def setUp(self) -> None:
+        self.state = QuantumState(TileType)
+
+    def test_init(self):
+        self.assertListEqual(
+            self.state.possible_states,
+            [
+                TileType.OCEAN,
+                TileType.SAND,
+                TileType.FOREST,
+                TileType.STONE,
+                TileType.GRASS,
+            ],
+        )
+
+    def test_collapse(self):
+        self.state.collapse(TileType.OCEAN)
+        self.assertListEqual(self.state.possible_states, [TileType.OCEAN])
+
+        self.state.collapse(TileType.SAND)
+        self.assertListEqual(self.state.possible_states, [TileType.SAND])
+
+    def test_remove_contrary_state(self):
+        self.state.remove_contrary_states(TileType.OCEAN, ISLAND_RULESET)
+        self.assertListEqual(
+            self.state.possible_states, [TileType.OCEAN, TileType.SAND]
+        )
+
+        self.state.collapse(TileType.OCEAN)
+        self.state.remove_contrary_states(TileType.OCEAN, ISLAND_RULESET)
+        self.assertListEqual(self.state.possible_states, [TileType.OCEAN])
+
+    def test_remove_contrary_state_stone(self):
+        self.state.remove_contrary_states(TileType.STONE, ISLAND_RULESET)
+        self.assertListEqual(
+            self.state.possible_states,
+            [TileType.SAND, TileType.FOREST, TileType.STONE, TileType.GRASS],
+        )
+
+        self.state.collapse(TileType.STONE)
+        self.state.remove_contrary_states(TileType.STONE, ISLAND_RULESET)
+        self.assertListEqual(self.state.possible_states, [TileType.STONE])
+
+
+class TestWaveFunctionCollapse(unittest.TestCase):
+    def setUp(self) -> None:
+        simple_island_values = [
+            [QuantumState(TileType) for _c in range(10)] for _r in range(10)
+        ]
+        simple_grid = Grid(simple_island_values, wrap_direction=WrapDirection.NONE)
+        desired_ratios = {TileType.STONE: 0.5, TileType.OCEAN: 0.5}
+        advanced_grid = HexGrid(simple_island_values, wrap_direction=WrapDirection.TORUS)
+
+        self.wfc = WaveFunctionCollapse(ISLAND_RULESET, simple_grid, desired_ratios)
+        self.adv_wfc = WaveFunctionCollapse(ISLAND_RULESET, advanced_grid, desired_ratios)
+
+    def test_collapse(self):
+        self.wfc.collapse()
+        self.assertTrue(len(self.wfc.uncollapsed()) == 0)
+
+        self.adv_wfc.collapse()
+        self.assertTrue(len(self.adv_wfc.uncollapsed()) == 0)
+
+

--- a/tests/unit/test_map.py
+++ b/tests/unit/test_map.py
@@ -1,0 +1,53 @@
+# pylint: disable=missing-docstring,line-too-long
+
+import unittest
+
+from src.tiled_tools.map.map import (
+    ISLAND_RULESET,
+    Tile,
+    TileRule,
+    TileRuleSet,
+    TileType,
+)
+
+
+class TestTileRuleSet(unittest.TestCase):
+    def setUp(self) -> None:
+        self.tile_rule_set = ISLAND_RULESET
+
+    def test_get_rule(self):
+        rule = self.tile_rule_set.get_rule(TileType.OCEAN)
+
+        self.assertIsInstance(rule, TileRule)
+        self.assertEqual(rule.tile_type, TileType.OCEAN)
+
+    def test_get_weight(self):
+        self.assertEqual(
+            self.tile_rule_set.get_weight(TileType.OCEAN, TileType.OCEAN), 0.5
+        )
+        self.assertEqual(
+            self.tile_rule_set.get_weight(TileType.OCEAN, TileType.SAND), 0.5
+        )
+        self.assertEqual(
+            self.tile_rule_set.get_weight(TileType.FOREST, TileType.OCEAN), 0.0
+        )
+        self.assertEqual(
+            self.tile_rule_set.get_weight(TileType.FOREST, TileType.SAND), 0.25
+        )
+
+    def test_is_allowed_neighbor(self):
+        self.assertTrue(
+            self.tile_rule_set.is_allowed_neighbor(TileType.OCEAN, TileType.OCEAN)
+        )
+        self.assertTrue(
+            self.tile_rule_set.is_allowed_neighbor(TileType.OCEAN, TileType.SAND)
+        )
+        self.assertFalse(
+            self.tile_rule_set.is_allowed_neighbor(TileType.FOREST, TileType.OCEAN)
+        )
+        self.assertFalse(
+            self.tile_rule_set.is_allowed_neighbor(TileType.OCEAN, TileType.FOREST)
+        )
+        self.assertTrue(
+            self.tile_rule_set.is_allowed_neighbor(TileType.FOREST, TileType.SAND)
+        )

--- a/tests/unit/test_queue.py
+++ b/tests/unit/test_queue.py
@@ -1,0 +1,125 @@
+# pylint: disable=missing-docstring,line-too-long
+
+import unittest
+
+from src.tiled_tools.common.queues import PriorityQueue, PriorityWrapper, Queue, Stack
+
+
+class TestQueue(unittest.TestCase):
+    def setUp(self) -> None:
+        self.queue = Queue()
+
+    def test_push(self):
+        self.queue.push(1)
+        self.assertEqual(len(self.queue), 1)
+
+        for i in range(10):
+            self.queue.push(i)
+
+        self.assertEqual(len(self.queue), 11)
+
+    def test_pop(self):
+        self.queue.push(1)
+        self.queue.push(3)
+        self.queue.push(2)
+
+        self.assertEqual(self.queue.pop(), 1)
+        self.assertEqual(self.queue.pop(), 3)
+        self.assertEqual(self.queue.pop(), 2)
+
+    def test_peek(self):
+        self.queue.push(1)
+        self.assertEqual(self.queue.peek(), 1)
+        self.queue.push(3)
+        self.queue.push(2)
+
+        self.assertEqual(self.queue.peek(), 1)
+        self.queue.pop()
+        self.assertEqual(self.queue.peek(), 3)
+        self.queue.pop()
+        self.assertEqual(self.queue.peek(), 2)
+
+
+class TestStack(unittest.TestCase):
+    def setUp(self) -> None:
+        self.stack = Stack()
+
+    def test_push(self):
+        self.stack.push(1)
+        self.assertEqual(len(self.stack), 1)
+
+        for i in range(10):
+            self.stack.push(i)
+
+        self.assertEqual(len(self.stack), 11)
+
+    def test_pop(self):
+        self.stack.push(1)
+        self.stack.push(3)
+        self.stack.push(2)
+
+        self.assertEqual(self.stack.pop(), 2)
+        self.assertEqual(self.stack.pop(), 3)
+        self.assertEqual(self.stack.pop(), 1)
+
+    def test_peek(self):
+        self.stack.push(1)
+        self.assertEqual(self.stack.peek(), 1)
+        self.stack.push(3)
+        self.stack.push(2)
+
+        self.assertEqual(self.stack.peek(), 2)
+        self.stack.pop()
+        self.assertEqual(self.stack.peek(), 3)
+        self.stack.pop()
+        self.assertEqual(self.stack.peek(), 1)
+
+
+class TestPriorityQueue(unittest.TestCase):
+    def setUp(self) -> None:
+        self.priority_queue = PriorityQueue()
+
+    def test_push(self):
+        self.priority_queue.push(1)
+        self.assertEqual(len(self.priority_queue), 1)
+
+        for i in range(10):
+            self.priority_queue.push(i)
+
+        for i in range(10):
+            self.priority_queue.push((i, i))
+
+        for i in range(10):
+            self.priority_queue.push(PriorityWrapper(i, i))
+
+        self.assertEqual(len(self.priority_queue), 31)
+
+    def test_pop_like_stack(self):
+        self.priority_queue.push(1)
+        self.priority_queue.push(3)
+        self.priority_queue.push(2)
+
+        self.assertEqual(self.priority_queue.pop(), 2)
+        self.assertEqual(self.priority_queue.pop(), 3)
+        self.assertEqual(self.priority_queue.pop(), 1)
+
+    def test_peek_like_stack(self):
+        self.priority_queue.push(1)
+        self.assertEqual(self.priority_queue.peek(), 1)
+        self.priority_queue.push(3)
+        self.priority_queue.push(2)
+
+        self.assertEqual(self.priority_queue.peek(), 2)
+        self.priority_queue.pop()
+        self.assertEqual(self.priority_queue.peek(), 3)
+        self.priority_queue.pop()
+        self.assertEqual(self.priority_queue.peek(), 1)
+
+    def test_priority_wrapper(self):
+        self.priority_queue.push(PriorityWrapper(1, 2))
+        self.priority_queue.push(PriorityWrapper(3, 1))
+        self.priority_queue.push(PriorityWrapper(2, 3))
+
+        self.assertEqual(self.priority_queue.pop(), 2)
+        self.assertEqual(self.priority_queue.pop(), 1)
+        self.assertEqual(self.priority_queue.pop(), 3)


### PR DESCRIPTION
This is an implementation of wave function collapse that uses the other functionality in the module. It can successfully generate grids. To be added, time and energy permitting: 

- Update `resolve_global_contrary_states` in case a generation fails by contradiction. This is not really possible with teh island ruleset as "SAND" is valid next to all tiles
- Utilize the desired_ratios during generation to have more control over randomness during generation
- Update to use Shannon entropy instead of random uncollapsed tile at each step
- Update generic typing, so that any Enum that's Tile-Like can be used
- Save/visualize the steps performed

There will also be a react frontend created because these grid are hard to conceptualize in a terminal.